### PR TITLE
Fix confusion between .warn and .info

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,9 @@ console.log = function (...args) {
 console.error = function (...args) {
   return logger.error.apply(logger, [...args]);
 };
-console.info = function (...args) {
+console.warn = function (...args) {
   return logger.warn.apply(logger, [...args]);
+};
+console.info = function (...args) {
+  return logger.info.apply(logger, [...args]);
 };


### PR DESCRIPTION
Fix console.info from logging warning instead of info 
Make console.warn use winston logger warn